### PR TITLE
Ignore publishing of config file if package is run under Lumen

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -25,7 +25,7 @@ class ServiceProvider extends Provider
     {
         if (!$this->isLumen()) {
             $this->publishes([
-                realpath(__DIR__ . '/../config/blameable.php') => config_path('blameable.php'),
+                realpath(__DIR__.'/../config/blameable.php') => config_path('blameable.php'),
             ], 'config');
         }
     }
@@ -37,7 +37,7 @@ class ServiceProvider extends Provider
      */
     public function register()
     {
-        $this->mergeConfigFrom(realpath(__DIR__ . '/../config/blameable.php'), 'blameable');
+        $this->mergeConfigFrom(realpath(__DIR__.'/../config/blameable.php'), 'blameable');
 
         $this->app->singleton(BlameableObserver::class, function () {
             return new BlameableObserver();

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -7,15 +7,27 @@ use Illuminate\Support\ServiceProvider as Provider;
 class ServiceProvider extends Provider
 {
     /**
+     * Check if the application runs with Lumen.
+     *
+     * @return bool
+     */
+    protected function isLumen()
+    {
+        return strpos($this->app->version(), 'Lumen') !== false;
+    }
+
+    /**
      * Bootstrap the application services.
      *
      * @return void
      */
     public function boot()
     {
-        $this->publishes([
-            realpath(__DIR__.'/../config/blameable.php') => config_path('blameable.php'),
-        ], 'config');
+        if (!$this->isLumen()) {
+            $this->publishes([
+                realpath(__DIR__ . '/../config/blameable.php') => config_path('blameable.php'),
+            ], 'config');
+        }
     }
 
     /**
@@ -25,7 +37,7 @@ class ServiceProvider extends Provider
      */
     public function register()
     {
-        $this->mergeConfigFrom(realpath(__DIR__.'/../config/blameable.php'), 'blameable');
+        $this->mergeConfigFrom(realpath(__DIR__ . '/../config/blameable.php'), 'blameable');
 
         $this->app->singleton(BlameableObserver::class, function () {
             return new BlameableObserver();


### PR DESCRIPTION
Hello, thanks for the good package, was exactly what I was looking for one of my projects.

Because we run Lumen and not Laravel, the publishing of the config file is apparently not possible. Still, if I included the package, my application crashed because Lumen was unable to push the config file. So I basically added a check in the ServiceProvider if the package is run under Lumen and if yes, it won't do this publishing thing.

Hope you can have a look and merge it if everything is good. Best regards, Andy