### PR TITLE
Fixes #22

### DIFF
--- a/src/BlameableTrait.php
+++ b/src/BlameableTrait.php
@@ -125,7 +125,7 @@ trait BlameableTrait
      */
     public function useSoftDeletes() :bool
     {
-        return in_array(SoftDeletes::class, class_uses($this), true);
+        return in_array(SoftDeletes::class, class_uses_recursive($this), true);
     }
 
     /**


### PR DESCRIPTION
This will allow `useSoftDeletes` to detect the trait up the inheritance tree, fixing the desired behavior.