### PR TITLE
Add Support For Laravel 11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,96 +2,102 @@ name: CI
 
 on:
   pull_request:
-    paths-ignore: ['*.md']
+    paths-ignore: ["*.md"]
   push:
-    paths-ignore: ['*.md']
+    paths-ignore: ["*.md"]
 
 jobs:
   analysis:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ 8.2 ]
+        php: [8.3]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, intl, gd, exif, iconv
           coverage: none
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache composer dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: eloquent-blameable-analysis
         with:
-          path: ~/.composer
+          path: ${{ steps.composer-cache.outputs.dir }}
           key: php-${{ matrix.php }}-build-${{ env.cache-name }}-${{ hashFiles('**/composer.json') }}
           restore-keys: |
             php-${{ matrix.php }}-build-${{ env.cache-name }}-
-            php-${{ matrix.php }}-build-
-            php-${{ matrix.php }}-
       - name: Install composer dependencies
         run: composer install --prefer-dist
       - name: Run static analysis
         run: composer analyse
   test:
     name: Test (PHP ${{ matrix.php }})
-    needs: [ analysis ]
+    needs: [analysis]
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [7.4, 8.0, 8.1]
+        php: [8.0, 8.1, 8.2]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, intl, gd, exif, iconv
           coverage: none
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache composer dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: eloquent-blameable-test
         with:
-          path: ~/.composer
+          path: ${{ steps.composer-cache.outputs.dir }}
           key: php-${{ matrix.php }}-build-${{ env.cache-name }}-${{ hashFiles('**/composer.json') }}
           restore-keys: |
             php-${{ matrix.php }}-build-${{ env.cache-name }}-
-            php-${{ matrix.php }}-build-
-            php-${{ matrix.php }}-
       - name: Install composer dependencies
         run: composer install --no-interaction --prefer-dist
       - name: Run PHPUnit tests
         run: vendor/bin/phpunit
   test-coverage:
     name: Test (PHP ${{ matrix.php }})
-    needs: [ analysis ]
+    needs: [analysis]
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ 8.2 ]
+        php: [8.3]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, intl, gd, exif, iconv
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache composer dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: eloquent-blameable-test
         with:
-          path: ~/.composer
+          path: ${{ steps.composer-cache.outputs.dir }}
           key: php-${{ matrix.php }}-build-${{ env.cache-name }}-${{ hashFiles('**/composer.json') }}
           restore-keys: |
             php-${{ matrix.php }}-build-${{ env.cache-name }}-
-            php-${{ matrix.php }}-build-
-            php-${{ matrix.php }}-
       - name: Install composer dependencies
         run: composer install --no-interaction --prefer-dist
       - name: Run PHPUnit tests and generate code coverage

--- a/composer.json
+++ b/composer.json
@@ -21,21 +21,19 @@
         "source": "https://github.com/richan-fongdasen/eloquent-blameable"
     },
     "require": {
-        "php": "^7.4|^8.0",
-        "illuminate/database": "^8.0|^9.0|^10.0",
-        "illuminate/support": "^8.0|^9.0|^10.0"
+        "php": "^8.0",
+        "illuminate/database": "^8.0|^9.0|^10.0|^11.0",
+        "illuminate/support": "^8.0|^9.0|^10.0|^11.0"
     },
     "require-dev": {
         "ekino/phpstan-banned-code": "^1.0",
-        "mockery/mockery": "^1.3",
-        "nunomaduro/larastan": "^1.0|^2.0",
-        "orchestra/database": "^6.0|dev-master",
-        "orchestra/testbench": "^6.0|^7.0|^8.0",
+        "larastan/larastan": "^1.0|^2.0",
+        "mockery/mockery": "^1.4",
+        "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0",
         "phpmd/phpmd": "^2.11",
         "phpstan/phpstan-deprecation-rules": "^1.0",
-        "phpstan/phpstan-strict-rules": "^1.1",
-        "phpunit/phpunit": "^9.5",
-        "sebastian/phpcpd": "^6.0"
+        "phpstan/phpstan-strict-rules": "^1.0",
+        "phpunit/phpunit": "^9.5|^10.0|^11.0"
     },
     "config": {
         "sort-packages": true
@@ -65,8 +63,7 @@
         "analyse": [
             "composer check-syntax",
             "composer phpstan-analysis",
-            "composer phpmd-analysis",
-            "vendor/bin/phpcpd --min-lines=3 --min-tokens=36 src/"
+            "composer phpmd-analysis"
         ],
         "check-syntax": [
             "! find src -type f -name \"*.php\" -exec php -l {} \\; |  grep -v 'No syntax errors'",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 includes:
-    - vendor/nunomaduro/larastan/extension.neon
+    - vendor/larastan/larastan/extension.neon
     - vendor/phpstan/phpstan-strict-rules/rules.neon
     - vendor/phpstan/phpstan-deprecation-rules/rules.neon
     - vendor/ekino/phpstan-banned-code/extension.neon

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" bootstrap="vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage>
-    <include>
-      <directory suffix=".php">src/</directory>
-    </include>
-  </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
   <testsuites>
     <testsuite name="Blameable Test Suite">
       <directory suffix="Tests.php">./tests/</directory>
     </testsuite>
   </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,5 @@
-
-![CI](https://github.com/richan-fongdasen/eloquent-blameable/workflows/CI/badge.svg?branch=master) 
+[![CI](https://github.com/richan-fongdasen/eloquent-blameable/actions/workflows/main.yml/badge.svg?branch=main)](https://github.com/richan-fongdasen/eloquent-blameable/actions/workflows/main.yml)
 [![codecov](https://codecov.io/gh/richan-fongdasen/eloquent-blameable/branch/master/graph/badge.svg)](https://codecov.io/gh/richan-fongdasen/eloquent-blameable)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/richan-fongdasen/eloquent-blameable/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/richan-fongdasen/eloquent-blameable/?branch=master)
 [![Total Downloads](https://poser.pugx.org/richan-fongdasen/eloquent-blameable/d/total.svg)](https://packagist.org/packages/richan-fongdasen/eloquent-blameable)
 [![Latest Stable Version](https://poser.pugx.org/richan-fongdasen/eloquent-blameable/v/stable.svg)](https://packagist.org/packages/richan-fongdasen/eloquent-blameable)
 [![License: MIT](https://poser.pugx.org/laravel/framework/license.svg)](https://opensource.org/licenses/MIT)
@@ -32,7 +30,7 @@ $ composer require richan-fongdasen/eloquent-blameable
 ### Laravel version compatibility
 
 | Laravel version | Blameable version |
-|:----------------|:------------------|
+| :-------------- | :---------------- |
 | 5.1.x           | 1.0.x             |
 | 5.2.x - 5.4.x   | 1.1.x - 1.2.x     |
 | 5.5.x - 5.8.x   | 1.3.x             |
@@ -41,6 +39,7 @@ $ composer require richan-fongdasen/eloquent-blameable
 | 8.x             | 1.6.x             |
 | 9.x             | 1.8.x             |
 | 10.x            | 1.9.x             |
+| 10.x            | 1.10.x            |
 
 > If you are using Laravel version 5.5+ then you can skip registering the service provider in your Laravel application.
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -4,7 +4,6 @@ use Illuminate\Database\Eloquent\Model;
 use RichanFongdasen\EloquentBlameable\BlameableService;
 
 if (!function_exists('blameable_user')) {
-
     /**
      * Get the blameable User identifier.
      *

--- a/tests/HelperTests.php
+++ b/tests/HelperTests.php
@@ -2,19 +2,20 @@
 
 namespace RichanFongdasen\EloquentBlameableTest;
 
+use PHPUnit\Framework\Attributes\Test;
 use RichanFongdasen\EloquentBlameableTest\Supports\Models\Article;
 use RichanFongdasen\EloquentBlameableTest\Supports\Models\Post;
 use RichanFongdasen\EloquentBlameableTest\Supports\Models\PostWithoutAttributes;
 
 class HelperTests extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_returns_null_as_current_user_identifier()
     {
         $this->assertNull(blameable_user(new Post));
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_current_user_identifier_when_calling_as_user()
     {
         $this->impersonateUser();
@@ -22,7 +23,7 @@ class HelperTests extends TestCase
         $this->assertEquals($this->user->getKey(), blameable_user(new Post));
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_current_user_identifier_when_calling_as_other_user()
     {
         $this->impersonateOtherUser();
@@ -30,7 +31,7 @@ class HelperTests extends TestCase
         $this->assertEquals($this->otherUser->getKey(), blameable_user(new Post));
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_null_as_current_user_identifier_when_current_user_is_other_class()
     {
         $this->impersonateUser();
@@ -38,7 +39,7 @@ class HelperTests extends TestCase
         $this->assertNull(blameable_user(new PostWithoutAttributes));
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_current_impersonated_admin_id()
     {
         $this->impersonateAdmin();
@@ -46,7 +47,7 @@ class HelperTests extends TestCase
         $this->assertEquals($this->admin->getKey(), blameable_user(new Article));
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_null_as_current_user_for_the_unauthenticated_user()
     {
         $this->assertNull(blameable_user(new Article));

--- a/tests/ObservedModelTests.php
+++ b/tests/ObservedModelTests.php
@@ -2,6 +2,7 @@
 
 namespace RichanFongdasen\EloquentBlameableTest;
 
+use PHPUnit\Framework\Attributes\Test;
 use RichanFongdasen\EloquentBlameableTest\Supports\Models\Comment;
 use RichanFongdasen\EloquentBlameableTest\Supports\Models\News;
 use RichanFongdasen\EloquentBlameableTest\Supports\Models\Post;
@@ -9,7 +10,7 @@ use RichanFongdasen\EloquentBlameableTest\Supports\Models\User;
 
 class ObservedModelTests extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_works_perfectly_on_creating_a_new_post()
     {
         $this->impersonateUser();
@@ -21,7 +22,7 @@ class ObservedModelTests extends TestCase
         $this->assertEquals($this->user->getKey(), $post->getAttribute('updated_by'));
     }
 
-    /** @test */
+    #[Test]
     public function it_works_perfectly_on_updating_existing_post()
     {
         $this->impersonateUser();
@@ -37,7 +38,7 @@ class ObservedModelTests extends TestCase
         $this->assertEquals($this->otherUser->getKey(), $post->getAttribute('updated_by'));
     }
 
-    /** @test */
+    #[Test]
     public function it_works_perfectly_on_deleting_post1()
     {
         $this->impersonateUser();
@@ -49,7 +50,7 @@ class ObservedModelTests extends TestCase
         $this->assertEquals($this->user->getKey(), $deletedPost->getAttribute('deleted_by'));
     }
 
-    /** @test */
+    #[Test]
     public function it_works_perfectly_on_deleting_post2()
     {
         $this->impersonateUser();
@@ -63,7 +64,7 @@ class ObservedModelTests extends TestCase
         $this->assertEquals($this->otherUser->getKey(), $deletedPost->getAttribute('deleted_by'));
     }
 
-    /** @test */
+    #[Test]
     public function it_works_perfectly_on_restoring_deleted_post()
     {
         $this->impersonateUser();
@@ -77,7 +78,7 @@ class ObservedModelTests extends TestCase
         $this->assertNull($restoredPost->getAttribute('deleted_by'));
     }
 
-    /** @test */
+    #[Test]
     public function it_works_perfectly_on_creating_a_new_comment()
     {
         $this->impersonateUser();
@@ -91,7 +92,7 @@ class ObservedModelTests extends TestCase
         $this->assertEquals($this->user->getKey(), $comment->getAttribute('updater_id'));
     }
 
-    /** @test */
+    #[Test]
     public function it_works_perfectly_on_updating_existing_comment()
     {
         $this->impersonateUser();
@@ -115,7 +116,7 @@ class ObservedModelTests extends TestCase
         $this->assertEquals($this->user->getKey(), $updatedPost->getAttribute('updated_by'));
     }
 
-    /** @test */
+    #[Test]
     public function it_works_perfectly_on_deleting_comment1()
     {
         $this->impersonateUser();
@@ -129,7 +130,7 @@ class ObservedModelTests extends TestCase
         $this->assertEquals($this->user->getKey(), $deletedComment->getAttribute('eraser_id'));
     }
 
-    /** @test */
+    #[Test]
     public function it_works_perfectly_on_deleting_comment2()
     {
         $this->impersonateUser();
@@ -145,7 +146,7 @@ class ObservedModelTests extends TestCase
         $this->assertEquals($this->otherUser->getKey(), $deletedComment->getAttribute('eraser_id'));
     }
 
-    /** @test */
+    #[Test]
     public function it_works_perfectly_on_restoring_deleted_comment()
     {
         $this->impersonateUser();
@@ -161,7 +162,7 @@ class ObservedModelTests extends TestCase
         $this->assertNull($restoredComment->getAttribute('deleted_by'));
     }
 
-    /** @test */
+    #[Test]
     public function it_works_perfectly_on_creating_a_new_user1()
     {
         $this->impersonateUser();
@@ -172,7 +173,7 @@ class ObservedModelTests extends TestCase
         $this->assertNull($this->user->getAttribute('updated_by'));
     }
 
-    /** @test */
+    #[Test]
     public function it_works_perfectly_on_creating_a_new_user2()
     {
         $this->impersonateUser();
@@ -184,7 +185,7 @@ class ObservedModelTests extends TestCase
         $this->assertEquals($this->user->getKey(), $this->otherUser->getAttribute('updated_by'));
     }
 
-    /** @test */
+    #[Test]
     public function it_works_perfectly_on_updating_existing_user()
     {
         $this->impersonateUser();
@@ -200,7 +201,7 @@ class ObservedModelTests extends TestCase
         $this->assertEquals($this->otherUser->getKey(), $user->getAttribute('updated_by'));
     }
 
-    /** @test */
+    #[Test]
     public function it_works_perfectly_on_deleting_user1()
     {
         $this->impersonateUser();
@@ -212,7 +213,7 @@ class ObservedModelTests extends TestCase
         $this->assertEquals($this->user->getKey(), $deletedUser->getAttribute('deleted_by'));
     }
 
-    /** @test */
+    #[Test]
     public function it_works_perfectly_on_deleting_user2()
     {
         $this->impersonateUser();
@@ -226,7 +227,7 @@ class ObservedModelTests extends TestCase
         $this->assertEquals($this->otherUser->getKey(), $deletedUser->getAttribute('deleted_by'));
     }
 
-    /** @test */
+    #[Test]
     public function it_works_perfectly_on_restoring_deleted_user()
     {
         $this->impersonateUser();
@@ -240,7 +241,7 @@ class ObservedModelTests extends TestCase
         $this->assertNull($restoredUser->getAttribute('deleted_by'));
     }
 
-    /** @test */
+    #[Test]
     public function it_will_set_null_creator_and_null_updater_on_unauthenticated_user()
     {
         $post = Post::factory()->create();
@@ -249,7 +250,7 @@ class ObservedModelTests extends TestCase
         $this->assertNull($post->getAttribute('updated_by'));
     }
 
-    /** @test */
+    #[Test]
     public function it_wont_cause_any_error_when_deleting_model_without_soft_deletes()
     {
         $this->impersonateAdmin();

--- a/tests/ServiceTests.php
+++ b/tests/ServiceTests.php
@@ -2,6 +2,7 @@
 
 namespace RichanFongdasen\EloquentBlameableTest;
 
+use PHPUnit\Framework\Attributes\Test;
 use RichanFongdasen\EloquentBlameableTest\Supports\Models\Comment;
 use RichanFongdasen\EloquentBlameableTest\Supports\Models\Post;
 use RichanFongdasen\EloquentBlameableTest\Supports\Models\PostOverrideAttributes;
@@ -18,14 +19,14 @@ class ServiceTests extends TestCase
      *
      * @return void
      */
-    public function setUp() :void
+    public function setUp(): void
     {
         parent::setUp();
 
         $this->service = new BlameableService();
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_configurations_correctly1()
     {
         $expected = [
@@ -41,7 +42,7 @@ class ServiceTests extends TestCase
         $this->assertEquals($expected, $result);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_configurations_correctly2()
     {
         $expected = [
@@ -57,7 +58,7 @@ class ServiceTests extends TestCase
         $this->assertEquals($expected, $result);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_configurations_correctly3()
     {
         $expected = [
@@ -73,7 +74,7 @@ class ServiceTests extends TestCase
         $this->assertEquals($expected, $result);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_configuration_value_correctly1()
     {
         $model = new Comment();
@@ -82,7 +83,7 @@ class ServiceTests extends TestCase
         $this->assertEquals(User::class, $result);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_configuration_value_correctly2()
     {
         $model = new Comment();
@@ -91,7 +92,7 @@ class ServiceTests extends TestCase
         $this->assertEquals('user_id', $result);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_configuration_value_correctly3()
     {
         $model = new Comment();
@@ -100,7 +101,7 @@ class ServiceTests extends TestCase
         $this->assertEquals('updater_id', $result);
     }
 
-    /** @test */
+    #[Test]
     public function it_would_set_attribute_value_correctly1()
     {
         $this->impersonateUser();
@@ -111,7 +112,7 @@ class ServiceTests extends TestCase
         $this->assertTrue($result);
     }
 
-    /** @test */
+    #[Test]
     public function it_would_set_attribute_value_correctly2()
     {
         $this->impersonateUser();
@@ -122,7 +123,7 @@ class ServiceTests extends TestCase
         $this->assertTrue($result);
     }
 
-    /** @test */
+    #[Test]
     public function it_would_set_attribute_value_correctly3()
     {
         $this->impersonateUser();
@@ -133,7 +134,7 @@ class ServiceTests extends TestCase
         $this->assertTrue($result);
     }
 
-    /** @test */
+    #[Test]
     public function it_would_set_attribute_value_correctly4()
     {
         $this->impersonateUser();

--- a/tests/Supports/Models/Admin.php
+++ b/tests/Supports/Models/Admin.php
@@ -26,4 +26,14 @@ class Admin extends Model implements Authenticatable
         'email',
         'password'
     ];
+
+    /**
+     * Get the name of the password attribute for the user.
+     *
+     * @return string
+     */
+    public function getAuthPasswordName()
+    {
+        return 'password';
+    }
 }

--- a/tests/Supports/Models/User.php
+++ b/tests/Supports/Models/User.php
@@ -21,4 +21,14 @@ class User extends Model implements Authenticatable
         'email',
         'password'
     ];
+
+    /**
+     * Get the name of the password attribute for the user.
+     *
+     * @return string
+     */
+    public function getAuthPasswordName()
+    {
+        return 'password';
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -78,7 +78,6 @@ abstract class TestCase extends BaseTest
     {
         return [
             \RichanFongdasen\EloquentBlameable\ServiceProvider::class,
-            \Orchestra\Database\ConsoleServiceProvider::class
         ];
     }
 
@@ -87,7 +86,7 @@ abstract class TestCase extends BaseTest
      *
      * @return void
      */
-    protected function impersonateAdmin() :void
+    protected function impersonateAdmin(): void
     {
         $this->admin = Admin::factory()->create([
             'id' => rand(300, 900)
@@ -101,7 +100,7 @@ abstract class TestCase extends BaseTest
      * @return void
      * @throws \Exception
      */
-    protected function impersonateOtherUser() :void
+    protected function impersonateOtherUser(): void
     {
         $this->otherUser = User::factory()->create([
             'id' => random_int(1000, 2000)
@@ -115,7 +114,7 @@ abstract class TestCase extends BaseTest
      * @return void
      * @throws \Exception
      */
-    protected function impersonateUser() :void
+    protected function impersonateUser(): void
     {
         $this->user = User::factory()->create([
             'id' => random_int(200, 900)
@@ -148,7 +147,7 @@ abstract class TestCase extends BaseTest
      * @param  string $migrationPath
      * @return void
      */
-    protected function prepareDatabase($migrationPath) :void
+    protected function prepareDatabase($migrationPath): void
     {
         $this->loadMigrationsFrom($migrationPath);
     }
@@ -159,7 +158,7 @@ abstract class TestCase extends BaseTest
      * @param  mixed $exception
      * @return void
      */
-    protected function prepareException($exception) :void
+    protected function prepareException($exception): void
     {
         if (method_exists($this, 'expectException')) {
             $this->expectException($exception);
@@ -173,11 +172,11 @@ abstract class TestCase extends BaseTest
      *
      * @return void
      */
-    public function setUp() :void
+    public function setUp(): void
     {
         parent::setUp();
 
-        $this->prepareDatabase(realpath(__DIR__.'/Supports/Migrations'));
+        $this->prepareDatabase(realpath(__DIR__ . '/Supports/Migrations'));
 
         Factory::guessFactoryNamesUsing(function (string $modelName) {
             return 'Database\\Factories\\' . class_basename($modelName) . 'Factory';

--- a/tests/TraitTests.php
+++ b/tests/TraitTests.php
@@ -2,6 +2,7 @@
 
 namespace RichanFongdasen\EloquentBlameableTest;
 
+use PHPUnit\Framework\Attributes\Test;
 use RichanFongdasen\EloquentBlameableTest\Supports\Models\Admin;
 use RichanFongdasen\EloquentBlameableTest\Supports\Models\Article;
 use RichanFongdasen\EloquentBlameableTest\Supports\Models\Post;
@@ -25,7 +26,7 @@ class TraitTests extends TestCase
      * @return void
      * @throws \Exception
      */
-    public function setUp() :void
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -45,7 +46,7 @@ class TraitTests extends TestCase
         $this->postB->save();
     }
 
-    /** @test */
+    #[Test]
     public function post_model_would_accept_created_by_scope1()
     {
         $collections = Post::createdBy($this->user->getKey())->get();
@@ -55,7 +56,7 @@ class TraitTests extends TestCase
         $this->assertTrue($collections->contains($this->postC));
     }
 
-    /** @test */
+    #[Test]
     public function post_model_would_accept_created_by_scope2()
     {
         $collections = Post::createdBy($this->otherUser)->get();
@@ -64,7 +65,7 @@ class TraitTests extends TestCase
         $this->assertTrue($collections->contains($this->postE));
     }
 
-    /** @test */
+    #[Test]
     public function post_model_would_accept_updated_by_scope1()
     {
         $collections = Post::updatedBy($this->user->getKey())->get();
@@ -73,7 +74,7 @@ class TraitTests extends TestCase
         $this->assertTrue($collections->contains($this->postC));
     }
 
-    /** @test */
+    #[Test]
     public function post_model_would_accept_updated_by_scope2()
     {
         $collections = Post::updatedBy($this->otherUser)->get();
@@ -83,7 +84,7 @@ class TraitTests extends TestCase
         $this->assertTrue($collections->contains($this->postE));
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_creator_user_object_correctly()
     {
         $this->assertInstanceOf(User::class, $this->postA->creator);
@@ -99,7 +100,7 @@ class TraitTests extends TestCase
         $this->assertEquals($this->otherUser->getKey(), $this->postE->creator->getKey());
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_updater_user_object_correctly()
     {
         $this->assertInstanceOf(User::class, $this->postA->updater);
@@ -107,7 +108,7 @@ class TraitTests extends TestCase
         $this->assertInstanceOf(User::class, $this->postC->updater);
         $this->assertInstanceOf(User::class, $this->postD->updater);
         $this->assertInstanceOf(User::class, $this->postE->updater);
-        
+
         $this->assertEquals($this->user->getKey(), $this->postA->updater->getKey());
         $this->assertEquals($this->user->getKey(), $this->postC->updater->getKey());
         $this->assertEquals($this->otherUser->getKey(), $this->postB->updater->getKey());
@@ -115,7 +116,7 @@ class TraitTests extends TestCase
         $this->assertEquals($this->otherUser->getKey(), $this->postE->updater->getKey());
     }
 
-    /** @test */
+    #[Test]
     public function article_model_would_accept_created_by_scope()
     {
         $collections = Article::createdBy($this->admin)->get();
@@ -125,7 +126,7 @@ class TraitTests extends TestCase
         $this->assertTrue($collections->contains($this->articleC));
     }
 
-    /** @test */
+    #[Test]
     public function article_model_would_accept_updated_by_scope()
     {
         $collections = Article::updatedBy($this->admin)->get();
@@ -135,7 +136,7 @@ class TraitTests extends TestCase
         $this->assertTrue($collections->contains($this->articleC));
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_creator_admin_object_correctly()
     {
         $this->assertInstanceOf(Admin::class, $this->articleA->creator);
@@ -147,7 +148,7 @@ class TraitTests extends TestCase
         $this->assertEquals($this->admin->getKey(), $this->articleC->creator->getKey());
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_updater_admin_object_correctly()
     {
         $this->assertInstanceOf(Admin::class, $this->articleA->updater);


### PR DESCRIPTION
* Add support for Laravel 11
* Add support for PHP 8.3
* Drop support for PHP 7.4
* Update package dependencies
* Update PHP Unit configuration
* Update the test codes from using doc-comment metadata to use PHP 8 attribute
* Update Github actions workflow's configuration
* Update readme